### PR TITLE
Improve Common Lisp implementation

### DIFF
--- a/lisp/quicksort.lisp
+++ b/lisp/quicksort.lisp
@@ -1,12 +1,8 @@
 (defun partition (f xs)
-  (labels ((aux (p1 p2 ys)
-                (if (null ys) (cons p1 p2)
-                    (destructuring-bind
-                      (head . tail) ys
-                      (if (funcall f head)
-                          (aux (cons head p1) p2 tail)
-                          (aux p1 (cons head p2) tail))))))
-          (aux '() '() xs)))
+  (loop for x in xs
+        if (funcall f x) collect x into l
+        else collect x into r
+        finally (return (cons l r))))
 
 (defun quicksort (xs)
   (if (null xs) xs

--- a/lisp/quicksort.lisp
+++ b/lisp/quicksort.lisp
@@ -5,7 +5,7 @@
         finally (return (values l r))))
 
 (defun quicksort (xs)
-  (if (null xs) xs
+  (when xs
     (let ((pivot (car xs)))
       (multiple-value-bind (l r) (partition (lambda (x) (< x pivot)) (cdr xs))
         (append (quicksort l) (list pivot) (quicksort r))))))

--- a/lisp/quicksort.lisp
+++ b/lisp/quicksort.lisp
@@ -2,13 +2,13 @@
   (loop for x in xs
         if (funcall f x) collect x into l
         else collect x into r
-        finally (return (cons l r))))
+        finally (return (values l r))))
 
 (defun quicksort (xs)
   (if (null xs) xs
-      (let* ((pivot (car xs))
-             (part (partition (lambda (x) (< x pivot)) (cdr xs))))
-        (append (quicksort (car part)) (list pivot) (quicksort (cdr part))))))
+    (let ((pivot (car xs)))
+      (multiple-value-bind (l r) (partition (lambda (x) (< x pivot)) (cdr xs))
+        (append (quicksort l) (list pivot) (quicksort r))))))
 
 (defvar n (read))
 (defvar xs (loop for i below n collect (read)))


### PR DESCRIPTION
This pull request attempts to make the Common Lisp implementation slightly more idiomatic. The `partition` method is changed to use `loop`, which is frequently used for writing iteration constructs. The same `partition` method is changed to return multiple values instead of a `cons` cell, using `multiple-value-bind` in `quicksort` to extract the returned values. Finally, there's no need to use `if` with two clauses, since `when` already returns an empty list when the predicate yields false.
